### PR TITLE
fix: also install nlohmann-json via vcpkg

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,9 @@
       "name": "lzo"
     },
     {
+      "name": "nlohmann-json"
+    },
+    {
       "name": "sdl2",
       "platform": "linux"
     },


### PR DESCRIPTION
For a short time-window this dependency was required for building OpenTTD.