### PR TITLE
chore: rename "benchmark" to "performance"

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,5 +1,5 @@
-name: Benchmark
-run-name: Benchmark (${{ inputs.date || 'scheduled' }})
+name: Performance
+run-name: Performance (${{ inputs.date || 'scheduled' }})
 
 on:
   schedule:


### PR DESCRIPTION
This removes the duplication in the GitHub Actions bar